### PR TITLE
Fix V591 warning from PVS-Studio Static Analyzer

### DIFF
--- a/RandomFerns.cpp
+++ b/RandomFerns.cpp
@@ -121,6 +121,7 @@ bool RandomFerns::Apply_Ferns(cv::Mat img,cv::Rect bbox, cv::Mat& init_pose){
 		posetmp.release();
 	}
 	init_pose = initpose2.clone();
+        return false;
 
 }
 void RandomFerns::get_linepoint(cv::Mat img,cv::Mat init_pose,std::vector<l1l2f1> line_pids, cv::Mat& feats){


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Non-void function should return a value.